### PR TITLE
set an explicit user/group in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN apk update &&\
 # - difficulties with docker volume mounting
 # - will not work properly in gcp cloud run (especially with data mounting)
 # TODO: revist in future if limitations are still true
-# RUN addgroup -S mondoo && adduser -S -G mondoo mondoo
-# USER mondoo
+RUN addgroup --gid 1001 -S mondoo && adduser --uid 1001 -S -G mondoo mondoo
+USER mondoo:mondoo
 ENTRYPOINT [ "mondoo" ]
 CMD ["help"]


### PR DESCRIPTION
This should allow us to run the Mondoo Client container in kubernetes with a securityContext of

RunAsNonRoot: true
RunAsUser: 1001

Which will let the Pod definitions pass more stringent security checks/policies.

Signed-off-by: Joel Diaz <joel@mondoo.com>