### PR TITLE
⭐ Build root and rootless mondoo client containers

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -68,9 +68,6 @@ jobs:
           build-args: VERSION=${{ steps.vars.outputs.tag }}
           target: rootless
           tags: |
-            mondoolabs/mondoo:${{ steps.vars.outputs.tag }}-rootless
-            mondoolabs/mondoo:${{ steps.semver.outputs.major }}-rootless
-            mondoolabs/mondoo:latest-rootless
             mondoo/client:${{ steps.vars.outputs.tag }}-rootless
             mondoo/client:${{ steps.semver.outputs.major }}-rootless
             mondoo/client:latest-rootless

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -43,30 +43,34 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           
-      - name: Build and push (alpine)
+      - name: Build and push root images
         uses: docker/build-push-action@v2
         with:
           context: .
           platforms: linux/386,linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7
           push: true
           build-args: VERSION=${{ steps.vars.outputs.tag }}
+          target: root
+          tags: |
+            mondoolabs/mondoo:${{ steps.vars.outputs.tag }}-root
+            mondoolabs/mondoo:${{ steps.semver.outputs.major }}-root
+            mondoolabs/mondoo:latest-root
+            mondoo/client:${{ steps.vars.outputs.tag }}-root
+            mondoo/client:${{ steps.semver.outputs.major }}-root
+            mondoo/client:latest-root
+
+      - name: Build and push non-root images
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/386,linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7
+          push: true
+          build-args: VERSION=${{ steps.vars.outputs.tag }}
+          target: non-root
           tags: |
             mondoolabs/mondoo:${{ steps.vars.outputs.tag }}
             mondoolabs/mondoo:${{ steps.semver.outputs.major }}
             mondoolabs/mondoo:latest
             mondoo/client:${{ steps.vars.outputs.tag }}
             mondoo/client:${{ steps.semver.outputs.major }}
-            mondoo/client:latest
-
-      - name: Build and push (ubi)
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          file: Dockerfile-ubi
-          platforms: linux/amd64,linux/arm64
-          push: true
-          build-args: VERSION=${{ steps.vars.outputs.tag }}
-          tags: |
-            mondoo/client:${{ steps.vars.outputs.tag }}-ubi
-            mondoo/client:${{ steps.semver.outputs.major }}-ubi
-            mondoo/client:latest-ubi
+            mondoo/client:latest   

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -43,7 +43,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           
-      - name: Build and push root images
+      - name: Build and push root images (alpine)
         uses: docker/build-push-action@v2
         with:
           context: .
@@ -52,25 +52,53 @@ jobs:
           build-args: VERSION=${{ steps.vars.outputs.tag }}
           target: root
           tags: |
-            mondoolabs/mondoo:${{ steps.vars.outputs.tag }}-root
-            mondoolabs/mondoo:${{ steps.semver.outputs.major }}-root
-            mondoolabs/mondoo:latest-root
-            mondoo/client:${{ steps.vars.outputs.tag }}-root
-            mondoo/client:${{ steps.semver.outputs.major }}-root
-            mondoo/client:latest-root
+            mondoolabs/mondoo:${{ steps.vars.outputs.tag }}
+            mondoolabs/mondoo:${{ steps.semver.outputs.major }}
+            mondoolabs/mondoo:latest
+            mondoo/client:${{ steps.vars.outputs.tag }}
+            mondoo/client:${{ steps.semver.outputs.major }}
+            mondoo/client:latest
 
-      - name: Build and push non-root images
+      - name: Build and push rootless images (alpine)
         uses: docker/build-push-action@v2
         with:
           context: .
           platforms: linux/386,linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7
           push: true
           build-args: VERSION=${{ steps.vars.outputs.tag }}
-          target: non-root
+          target: rootless
           tags: |
-            mondoolabs/mondoo:${{ steps.vars.outputs.tag }}
-            mondoolabs/mondoo:${{ steps.semver.outputs.major }}
-            mondoolabs/mondoo:latest
-            mondoo/client:${{ steps.vars.outputs.tag }}
-            mondoo/client:${{ steps.semver.outputs.major }}
-            mondoo/client:latest   
+            mondoolabs/mondoo:${{ steps.vars.outputs.tag }}-rootless
+            mondoolabs/mondoo:${{ steps.semver.outputs.major }}-rootless
+            mondoolabs/mondoo:latest-rootless
+            mondoo/client:${{ steps.vars.outputs.tag }}-rootless
+            mondoo/client:${{ steps.semver.outputs.major }}-rootless
+            mondoo/client:latest-rootless
+
+      - name: Build and push root images (ubi)
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile-ubi
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: VERSION=${{ steps.vars.outputs.tag }}
+          target: root
+          tags: |
+            mondoo/client:${{ steps.vars.outputs.tag }}-ubi
+            mondoo/client:${{ steps.semver.outputs.major }}-ubi
+            mondoo/client:latest-ubi
+
+      - name: Build and push rootless images (ubi)
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile-ubi
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: VERSION=${{ steps.vars.outputs.tag }}
+          target: rootless
+          tags: |
+            mondoo/client:${{ steps.vars.outputs.tag }}-ubi-rootless
+            mondoo/client:${{ steps.semver.outputs.major }}-ubi-rootless
+            mondoo/client:latest-ubi-rootless

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
 # Mondoo Multi-Architecture Container Dockerfile
 # 
-# To build with BuildX:   docker buildx build --build-arg VERSION=5.21.0 --platform 
-#             linux/386,linux/amd64,linux/arm/v7,linux/arm64 -t mondoolabs/mondoo:5.21.0 . --push
+# To build root images with BuildX:   docker buildx build --build-arg VERSION=5.21.0 --platform 
+#             linux/386,linux/amd64,linux/arm/v7,linux/arm64 --target root -t mondoolabs/mondoo:5.21.0 . --push
+#
+# To build non-root images with BuildX:   docker buildx build --build-arg VERSION=5.21.0 --platform 
+#             linux/386,linux/amd64,linux/arm/v7,linux/arm64 --target non-root -t mondoolabs/mondoo:5.21.0 . --push
 
-FROM alpine:3.15
+FROM alpine:3.15 AS root
 ARG VERSION
 
 ARG TARGETOS
@@ -23,13 +26,13 @@ RUN apk update &&\
     rm -f ${PACKAGE} SHA256SUMS &&\
     apk del wget tar --quiet &&\
     rm -rf /var/cache/apk/*
-
-# Note: we would prefer to use our own user to ensure the image does not run in root, but this comes with a lot of
-# limitations:
-# - difficulties with docker volume mounting
-# - will not work properly in gcp cloud run (especially with data mounting)
-# TODO: revist in future if limitations are still true
-# RUN addgroup -S mondoo && adduser -S -G mondoo mondoo
-# USER mondoo
+ 
 ENTRYPOINT [ "mondoo" ]
 CMD ["help"]
+
+# Non-root version of the container
+FROM base AS non-root
+
+RUN addgroup -S mondoo && adduser -S -G mondoo mondoo
+USER mondoo
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,8 @@ RUN apk update &&\
 ENTRYPOINT [ "mondoo" ]
 CMD ["help"]
 
-# Non-root version of the container
-FROM base AS non-root
+# Rootless version of the container
+FROM root AS rootless
 
 RUN addgroup -S mondoo && adduser -S -G mondoo mondoo
 USER mondoo

--- a/Dockerfile-ubi
+++ b/Dockerfile-ubi
@@ -3,7 +3,7 @@
 # To build with BuildX:   docker buildx build --build-arg VERSION=5.21.0 --platform 
 #             linux/amd64,linux/arm64 -t mondoolabs/mondoo:5.21.0 . --push
 
-FROM redhat/ubi8-minimal AS root
+FROM registry.access.redhat.com/ubi8-minimal AS root
 ARG VERSION
 
 ARG TARGETOS

--- a/Dockerfile-ubi
+++ b/Dockerfile-ubi
@@ -29,6 +29,4 @@ CMD ["help"]
 
 # Rootless version of the container
 FROM root AS rootless
-
-RUN groupadd -r mondoo && adduser -r -g mondoo mondoo
-USER mondoo
+USER 100:101

--- a/Dockerfile-ubi
+++ b/Dockerfile-ubi
@@ -1,9 +1,9 @@
 # Mondoo Multi-Architecture Container Dockerfile
 # 
 # To build with BuildX:   docker buildx build --build-arg VERSION=5.21.0 --platform 
-#             linux/386,linux/amd64,linux/arm/v7,linux/arm64 -t mondoolabs/mondoo:5.21.0 . --push
+#             linux/amd64,linux/arm64 -t mondoolabs/mondoo:5.21.0 . --push
 
-FROM redhat/ubi8
+FROM redhat/ubi8 AS root
 ARG VERSION
 
 ARG TARGETOS
@@ -24,12 +24,11 @@ RUN yum upgrade -y &&\
     yum remove wget tar --quiet -y &&\
     rm -rf /var/cache/dnf/*
 
-# Note: we would prefer to use our own user to ensure the image does not run in root, but this comes with a lot of
-# limitations:
-# - difficulties with docker volume mounting
-# - will not work properly in gcp cloud run (especially with data mounting)
-# TODO: revist in future if limitations are still true
-# RUN addgroup -S mondoo && adduser -S -G mondoo mondoo
-# USER mondoo
 ENTRYPOINT [ "mondoo" ]
 CMD ["help"]
+
+# Rootless version of the container
+FROM root AS rootless
+
+RUN groupadd -r mondoo && adduser -r -g mondoo mondoo
+USER mondoo

--- a/Dockerfile-ubi
+++ b/Dockerfile-ubi
@@ -3,7 +3,7 @@
 # To build with BuildX:   docker buildx build --build-arg VERSION=5.21.0 --platform 
 #             linux/amd64,linux/arm64 -t mondoolabs/mondoo:5.21.0 . --push
 
-FROM redhat/ubi8 AS root
+FROM redhat/ubi8-minimal AS root
 ARG VERSION
 
 ARG TARGETOS

--- a/Dockerfile-ubi
+++ b/Dockerfile-ubi
@@ -13,15 +13,15 @@ ARG TARGETVARIANT
 ARG BASEURL="https://releases.mondoo.com/mondoo/${VERSION}"
 ARG PACKAGE="mondoo_${VERSION}_${TARGETOS}_${TARGETARCH}${TARGETVARIANT}.tar.gz"
 
-RUN yum upgrade -y &&\
-    yum install wget tar rpm -y &&\
+RUN microdnf upgrade -y &&\
+    microdnf install wget tar rpm gzip -y &&\
     wget --quiet --output-document=SHA256SUMS ${BASEURL}/checksums.linux.txt &&\
     wget --quiet --output-document=${PACKAGE} ${BASEURL}/${PACKAGE} &&\
     cat SHA256SUMS | grep "${PACKAGE}" | sha256sum -c - &&\
     tar -xzC /usr/local/bin -f ${PACKAGE} &&\
     /usr/local/bin/mondoo version &&\
     rm -f ${PACKAGE} SHA256SUMS &&\
-    yum remove wget tar --quiet -y &&\
+    microdnf remove wget tar gzip -y &&\
     rm -rf /var/cache/dnf/*
 
 ENTRYPOINT [ "mondoo" ]

--- a/dockerhub/mondoo/client.md
+++ b/dockerhub/mondoo/client.md
@@ -27,6 +27,17 @@ Supported tags are:
 
 The `Dockerfile` for these images can be found [here](https://github.com/mondoohq/client/blob/master/Dockerfile-ubi).
 
+## Rootless containers
+The default Mondoo Client container runs our binary as the `root` user. This makes it easy to run a filesystem scan on the host or to use our Cloud Run capabilities. If neither of these use-cases are applicable, we recommend using the rootless containers that we offer. Instead of running under the `root` user, the Mondoo Client will run using the `mondoo` user.
+
+Supported tags are:
+- `latest-rootless`
+- `latest-ubi-rootless`
+- `6-rootless`
+- `6-ubi-rootless`
+- `6.4.0-rootless`
+- `6.4.0-ubi-rootless`
+
 # What is Mondoo
 
 Mondoo is a cloud security platform for infrastructure developers. Using Mondoo, your team will get an automated risk assessment and real-time insights into all of your business-critical infrastructure, across all of your infrastructure platforms.

--- a/dockerhub/mondoolabs/mondoo.md
+++ b/dockerhub/mondoolabs/mondoo.md
@@ -1,5 +1,7 @@
 ![Mondoo](https://mondoo.com/docs/img/mondoo.logo.svg)
 
+> This is a legacy repo. We recommend using [mondoo/client](https://hub.docker.com/r/mondoo/client) instead.
+
 # Quick reference
 
 * Basic use: ```docker run mondoo/client <args>```


### PR DESCRIPTION
As we discussed, we need 2 different flavours of the Mondoo client container - using `root` and `mondoo` user. This PR adjusts the `Dockerfile` and the related workflow for releasing it.

- [ ] Update Dockerhub readme (I don't have access to do it myself)

Signed-off-by: Ivan Milchev <ivan@mondoo.com>