### PR TITLE
⭐ Create UBI Mondoo client containers

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -67,9 +67,6 @@ jobs:
           push: true
           build-args: VERSION=${{ steps.vars.outputs.tag }}
           tags: |
-            mondoolabs/mondoo:${{ steps.vars.outputs.tag }}-ubi
-            mondoolabs/mondoo:${{ steps.semver.outputs.major }}-ubi
-            mondoolabs/mondoo:latest-ubi
             mondoo/client:${{ steps.vars.outputs.tag }}-ubi
             mondoo/client:${{ steps.semver.outputs.major }}-ubi
             mondoo/client:latest-ubi

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -43,7 +43,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           
-      - name: Build and push
+      - name: Build and push (alpine)
         uses: docker/build-push-action@v2
         with:
           context: .
@@ -56,4 +56,20 @@ jobs:
             mondoolabs/mondoo:latest
             mondoo/client:${{ steps.vars.outputs.tag }}
             mondoo/client:${{ steps.semver.outputs.major }}
-            mondoo/client:latest        
+            mondoo/client:latest
+
+      - name: Build and push (ubi)
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile-ubi
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: VERSION=${{ steps.vars.outputs.tag }}
+          tags: |
+            mondoolabs/mondoo:ubi-${{ steps.vars.outputs.tag }}
+            mondoolabs/mondoo:ubi-${{ steps.semver.outputs.major }}
+            mondoolabs/mondoo:ubi-latest
+            mondoo/client:ubi-${{ steps.vars.outputs.tag }}
+            mondoo/client:ubi-${{ steps.semver.outputs.major }}
+            mondoo/client:ubi-latest    

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -67,9 +67,9 @@ jobs:
           push: true
           build-args: VERSION=${{ steps.vars.outputs.tag }}
           tags: |
-            mondoolabs/mondoo:ubi-${{ steps.vars.outputs.tag }}
-            mondoolabs/mondoo:ubi-${{ steps.semver.outputs.major }}
-            mondoolabs/mondoo:ubi-latest
-            mondoo/client:ubi-${{ steps.vars.outputs.tag }}
-            mondoo/client:ubi-${{ steps.semver.outputs.major }}
-            mondoo/client:ubi-latest    
+            mondoolabs/mondoo:${{ steps.vars.outputs.tag }}-ubi
+            mondoolabs/mondoo:${{ steps.semver.outputs.major }}-ubi
+            mondoolabs/mondoo:latest-ubi
+            mondoo/client:${{ steps.vars.outputs.tag }}-ubi
+            mondoo/client:${{ steps.semver.outputs.major }}-ubi
+            mondoo/client:latest-ubi

--- a/Dockerfile-ubi
+++ b/Dockerfile-ubi
@@ -1,0 +1,35 @@
+# Mondoo Multi-Architecture Container Dockerfile
+# 
+# To build with BuildX:   docker buildx build --build-arg VERSION=5.21.0 --platform 
+#             linux/386,linux/amd64,linux/arm/v7,linux/arm64 -t mondoolabs/mondoo:5.21.0 . --push
+
+FROM redhat/ubi8
+ARG VERSION
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+
+ARG BASEURL="https://releases.mondoo.com/mondoo/${VERSION}"
+ARG PACKAGE="mondoo_${VERSION}_${TARGETOS}_${TARGETARCH}${TARGETVARIANT}.tar.gz"
+
+RUN yum upgrade -y &&\
+    yum install wget tar rpm -y &&\
+    wget --quiet --output-document=SHA256SUMS ${BASEURL}/checksums.linux.txt &&\
+    wget --quiet --output-document=${PACKAGE} ${BASEURL}/${PACKAGE} &&\
+    cat SHA256SUMS | grep "${PACKAGE}" | sha256sum -c - &&\
+    tar -xzC /usr/local/bin -f ${PACKAGE} &&\
+    /usr/local/bin/mondoo version &&\
+    rm -f ${PACKAGE} SHA256SUMS &&\
+    yum remove wget tar --quiet -y &&\
+    rm -rf /var/cache/dnf/*
+
+# Note: we would prefer to use our own user to ensure the image does not run in root, but this comes with a lot of
+# limitations:
+# - difficulties with docker volume mounting
+# - will not work properly in gcp cloud run (especially with data mounting)
+# TODO: revist in future if limitations are still true
+# RUN addgroup -S mondoo && adduser -S -G mondoo mondoo
+# USER mondoo
+ENTRYPOINT [ "mondoo" ]
+CMD ["help"]


### PR DESCRIPTION
Note that the UBI container supports the following platforms:
- linux/amd64
- linux/arm64
- linux/ppc64le
- linux/s390x

We have Mondoo client binaries only for the first 2 platforms. To test this, you can use:
```bash
docker build --build-arg VERSION=6.3.0 --platform linux/arm64 -f Dockerfile-ubi -t mondoo/client:ubi .
```

Signed-off-by: Ivan Milchev <ivan@mondoo.com>