### PR TITLE
exclude enterprise msi package from the windows download array

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -48,7 +48,7 @@ function Install-Mondoo {
     $wc = New-Object Net.Webclient
     $wc.Headers.Add('User-Agent', (Get-UserAgent))
     $latest = $wc.DownloadString($url) | ConvertFrom-Json 
-    $entry = $latest.files | where { $_.platform -eq "windows" -and $_.filename -match "${filetype}$" }
+    $entry = $latest.files | where { $_.platform -eq "windows" -and $_.filename -match "${filetype}$" -and $_.filename -NotMatch "enterprise" }
     $entry.filename
   }
 


### PR DESCRIPTION
result before fix:

```
PS C:\Users\Administrator> $entry = $latest.files | where { $_.platform -eq "windows" -and $_.filename -match "${filetype}$" }
PS C:\Users\Administrator>     $entry.filename
https://releases.mondoo.com/mondoo/6.4.0/mondoo_6.4.0_windows_amd64.msi
https://releases.mondoo.com/mondoo/6.4.0/mondoo_enterprise_6.4.0_windows_amd64.msi
```

Problem is that we get to msi packages

result after fix:

```
PS C:\Users\Administrator> $entry = $latest.files | where { $_.platform -eq "windows" -and $_.filename -match "${filetype}$" -and $_.filename -NotMatch "enterprise" }
PS C:\Users\Administrator> $entry.filename
https://releases.mondoo.com/mondoo/6.4.0/mondoo_6.4.0_windows_amd64.msi
```

Signed-off-by: Patrick Münch <patrick.muench1111@gmail.com>