### PR TITLE
use minimal UBI image

### DIFF
--- a/Dockerfile-ubi
+++ b/Dockerfile-ubi
@@ -3,7 +3,7 @@
 # To build with BuildX:   docker buildx build --build-arg VERSION=5.21.0 --platform 
 #             linux/386,linux/amd64,linux/arm/v7,linux/arm64 -t mondoolabs/mondoo:5.21.0 . --push
 
-FROM redhat/ubi8
+FROM redhat/ubi8-minimal
 ARG VERSION
 
 ARG TARGETOS

--- a/Dockerfile-ubi
+++ b/Dockerfile-ubi
@@ -3,7 +3,7 @@
 # To build with BuildX:   docker buildx build --build-arg VERSION=5.21.0 --platform 
 #             linux/386,linux/amd64,linux/arm/v7,linux/arm64 -t mondoolabs/mondoo:5.21.0 . --push
 
-FROM redhat/ubi8-minimal
+FROM registry.access.redhat.com/ubi8-minimal
 ARG VERSION
 
 ARG TARGETOS


### PR DESCRIPTION
No need for the more fully-featured UBI image, so use the minimal one to reduce container size and security surface area.

Also, pull from Red Hat's container registry directly.