### PR TITLE
⭐ Trigger mondoo-operator integration tests after pushing edge containers

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Start mondoo-operator integration tests
         run: |
-          curl \
+          curl -s \
             -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: token ${{ secrets.REPO_API_TOKEN }}" \

--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -66,6 +66,6 @@ jobs:
           curl \
             -X POST \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: token ${GITHUB_API_TOKEN}" \
+            -H "Authorization: token ${REPO_API_TOKEN}" \
             https://api.github.com/repos/mondoohq/mondoo-operator/actions/workflows/31262606/dispatches \
             -d "{\"ref\":\"master\",\"inputs\":{\"mondooClientImageTag\":\"edge-${{ github.event.inputs.version }}-rootless\"}}"

--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -45,7 +45,6 @@ jobs:
           target: root
           tags: |
             mondoo/client:edge-${{ github.event.inputs.version }}
-            mondoo/client:edge-${{ github.event.inputs.version }}
             mondoo/client:edge-latest
 
       - name: Build and push rootless images (alpine)
@@ -60,5 +59,13 @@ jobs:
           target: rootless
           tags: |
             mondoo/client:edge-${{ github.event.inputs.version }}-rootless
-            mondoo/client:edge-${{ github.event.inputs.version }}-rootless
             mondoo/client:edge-latest-rootless
+
+      - name: Start mondoo-operator integration tests
+        run: |
+          curl \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: token ${GITHUB_API_TOKEN}" \
+            https://api.github.com/repos/mondoohq/mondoo-operator/actions/workflows/31262606/dispatches \
+            -d "{\"ref\":\"master\",\"inputs\":{\"mondooClientImageTag\":\"edge-${{ github.event.inputs.version }}-rootless\"}}"

--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -66,6 +66,6 @@ jobs:
           curl \
             -X POST \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: token ${REPO_API_TOKEN}" \
+            -H "Authorization: token ${{ secrets.REPO_API_TOKEN }}" \
             https://api.github.com/repos/mondoohq/mondoo-operator/actions/workflows/31262606/dispatches \
-            -d "{\"ref\":\"master\",\"inputs\":{\"mondooClientImageTag\":\"edge-${{ github.event.inputs.version }}-rootless\"}}"
+            -d "{\"ref\":\"main\",\"inputs\":{\"mondooClientImageTag\":\"edge-${{ github.event.inputs.version }}-rootless\"}}"


### PR DESCRIPTION
- [x] Add a step to trigger the mondoo-operator integration tests with the new edge container
- [x] Add github token as a secret `GITHUB_API_TOKEN`

This can only be merged after we have the secret configured for this repo

Signed-off-by: Ivan Milchev <ivan@mondoo.com>