### PR TITLE
Refined update-revision job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,19 +42,31 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v3
-      - name: Get Latest Tag
+        with:
+          ref: 'master'
+          fetch-depth: 0
+      - name: Version from Workflow Dispatch
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
+      - name: Version from Release Tag
+        if: github.event_name == 'release'
+        run: |
+          echo "VERSION=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
+      - name: Verify valid version
         id: vars
-        uses: WyriHaximus/github-action-get-previous-tag@v1
-      # runs go to generate the update
-      - run: |
-          echo '${{ steps.vars.outputs.tag }}' > VERSION
-      # Commit changes
+        run: |
+          if [[ ! $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid version: $VERSION"
+            exit 1
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
       - name: Commit VERSION file
         run: |
-          echo 'VERSION is ${{ steps.vars.outputs.tag }}'
-          git checkout master
+          echo ${VERSION} > VERSION
+          echo "VERSION is $VERSION"
           git add VERSION
           git config --global user.email "tools@mondoo.com"
           git config --global user.name "Mondoo Tools"
-          git commit -m 'Update VERSION to ${{ steps.vars.outputs.tag }}'
-          git push origin master -f
+          git commit -m "Update VERSION to $VERSION"
+          git push 


### PR DESCRIPTION
This update was honed in a fork to provide the following improvements:

- Release events, when interpreted by actions/checkout@v3, provide a checkout of a single commit, that of the release tag, which results in a Git detached head which can't be rectified by changing branches or using git switch.  The solution is to checkout on the reference 'master', so that regardless of the event which invoked the job the HEAD is present and able to be commited against.
- Version can be specified either manually on a manual invocation (not ideal but provided as a fallback, just in case) or properly via the release publish event.
- Force push no longer required
- Simplified set of steps

Signed-off-by: Ben Rockwood <benr@cuddletech.com>