### PR TITLE
🧹 add shellcheck to github action workflow

### DIFF
--- a/.github/workflows/test_scripts.yml
+++ b/.github/workflows/test_scripts.yml
@@ -1,0 +1,20 @@
+---
+name: ShellCheck
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions: {}
+
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
+        with:
+          ignore_paths: examples
+          scandir: '.'


### PR DESCRIPTION
runs the shell check task as part of the workflow. You can still run it locally with `make test/shellcheck`