### PR TITLE
🧹 Disable operator edge integration tests integration

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -60,12 +60,3 @@ jobs:
           tags: |
             mondoo/client:edge-${{ github.event.inputs.version }}-rootless
             mondoo/client:edge-latest-rootless
-
-      - name: Start mondoo-operator integration tests
-        run: |
-          curl -s \
-            -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: token ${{ secrets.REPO_API_TOKEN }}" \
-            https://api.github.com/repos/mondoohq/mondoo-operator/actions/workflows/31262606/dispatches \
-            -d "{\"ref\":\"main\",\"inputs\":{\"mondooClientImageTag\":\"edge-${{ github.event.inputs.version }}-rootless\"}}"


### PR DESCRIPTION
This will be moved to cnspec since the operator is moving away from using the Mondoo client

- [x] Remove `REPO_API_TOKEN` secret as it is no longer needed